### PR TITLE
Update scripted costs

### DIFF
--- a/src/ck3/data/scripted_costs.rs
+++ b/src/ck3/data/scripted_costs.rs
@@ -46,6 +46,9 @@ impl DbKind for ScriptedCost {
                 sc = ScopeContext::new(Scopes::LandedTitle, key);
                 sc.define_name("actor", Scopes::Character, key);
             }
+            "reform_culture_ethos" | "reform_culture_language" | "reform_culture_martial" => {
+                sc = ScopeContext::new(Scopes::Culture, key);
+            }
             _ => {
                 sc.set_strict_scopes(false);
             }

--- a/src/ck3/data/scripted_costs.rs
+++ b/src/ck3/data/scripted_costs.rs
@@ -42,6 +42,10 @@ impl DbKind for ScriptedCost {
             "create_accolade" => {
                 sc.define_name("owner", Scopes::Character, key)
             }
+            "reassign_title_troops" => {
+                sc = ScopeContext::new(Scopes::LandedTitle, key);
+                sc.define_name("actor", Scopes::Character, key);
+            }
             _ => {
                 sc.set_strict_scopes(false);
             }

--- a/src/ck3/data/scripted_costs.rs
+++ b/src/ck3/data/scripted_costs.rs
@@ -26,11 +26,11 @@ impl DbKind for ScriptedCost {
         let mut sc = ScopeContext::new(Scopes::Character, key);
         match key.as_str() {
             "hybridize_culture" => {
-                sc.define_name("culture", Scopes::Culture, key)
+                sc.define_name("culture", Scopes::Culture, key);
             }
             "reforge_artifact" | "repair_artifact" => {
                 sc = ScopeContext::new(Scopes::None, key);
-                sc.define_name("artifact", Scopes::Artifact, key)
+                sc.define_name("artifact", Scopes::Artifact, key);
             }
             "travel_leader" => {
                 sc.define_name("speed_aptitude", Scopes::Value, key);
@@ -40,7 +40,7 @@ impl DbKind for ScriptedCost {
                 sc = ScopeContext::new(Scopes::Accolade, key);
             }
             "create_accolade" => {
-                sc.define_name("owner", Scopes::Character, key)
+                sc.define_name("owner", Scopes::Character, key);
             }
             "reassign_title_troops" => {
                 sc = ScopeContext::new(Scopes::LandedTitle, key);

--- a/src/ck3/data/scripted_costs.rs
+++ b/src/ck3/data/scripted_costs.rs
@@ -24,18 +24,27 @@ impl ScriptedCost {
 impl DbKind for ScriptedCost {
     fn validate(&self, key: &Token, block: &Block, data: &Everything) {
         let mut sc = ScopeContext::new(Scopes::Character, key);
-        if key.is("hybridize_culture") {
-            sc.define_name("culture", Scopes::Culture, key);
-        } else if key.is("reforge_artifact") || key.is("repair_artifact") {
-            sc = ScopeContext::new(Scopes::None, key);
-            sc.define_name("artifact", Scopes::Artifact, key);
-        } else if key.is("travel_leader") {
-            sc.define_name("speed_aptitude", Scopes::Value, key);
-            sc.define_name("safety_aptitude", Scopes::Value, key);
-        } else if key.is("deactivate_accolade") {
-            sc = ScopeContext::new(Scopes::Accolade, key);
-        } else if key.is("create_accolade") {
-            sc.define_name("owner", Scopes::Character, key);
+        match key.as_str() {
+            "hybridize_culture" => {
+                sc.define_name("culture", Scopes::Culture, key)
+            }
+            "reforge_artifact" | "repair_artifact" => {
+                sc = ScopeContext::new(Scopes::None, key);
+                sc.define_name("artifact", Scopes::Artifact, key)
+            }
+            "travel_leader" => {
+                sc.define_name("speed_aptitude", Scopes::Value, key);
+                sc.define_name("safety_aptitude", Scopes::Value, key);
+            }
+            "deactivate_accolade" => {
+                sc = ScopeContext::new(Scopes::Accolade, key);
+            }
+            "create_accolade" => {
+                sc.define_name("owner", Scopes::Character, key)
+            }
+            _ => {
+                sc.set_strict_scopes(false);
+            }
         }
 
         validate_cost(block, data, &mut sc);


### PR DESCRIPTION
close #205 

- refactored validate costs to use pattern matching 
- validate reassign_title_troops with landed_title scope
- validate reform_culture_* with culture scope

### example:
![image](https://github.com/user-attachments/assets/6b821b9d-ebb9-4336-baf0-f1fc14cb4737)
