### PR TITLE
Accept glob patterns in file filters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -911,6 +911,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "h2"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2631,6 +2637,7 @@ dependencies = [
  "bitvec",
  "bumpalo",
  "encoding_rs",
+ "glob",
  "image",
  "inventory",
  "lalrpop",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ ahash = { version = "0.8", features = [
     "compile-time-rng",
 ], default-features = false }
 murmur3 = "0.5.2"
+glob = "0.3.2"
 
 [profile.bench]
 debug = true

--- a/src/config_load.rs
+++ b/src/config_load.rs
@@ -280,7 +280,7 @@ fn load_keys_array(array_block: &Block) -> Option<FilterRule> {
 fn load_files_array(array_block: &Block) -> Option<FilterRule> {
     let files: Vec<_> = array_block
         .iter_values_warn()
-        .map(|token| FilterRule::File(PathBuf::from(token.as_str())))
+        .filter_map(FilterRule::file_from_token)
         .collect();
     if files.is_empty() {
         None
@@ -374,7 +374,7 @@ fn load_rule_file(value: &BV) -> Option<FilterRule> {
             ).loc(value).push();
             None
         }
-        BV::Value(token) => Some(FilterRule::File(PathBuf::from(token.as_str()))),
+        BV::Value(token) => FilterRule::file_from_token(token),
     }
 }
 

--- a/src/report/builder.rs
+++ b/src/report/builder.rs
@@ -104,7 +104,6 @@ impl ReportBuilderStage2 {
         }
     }
 
-    #[cfg(feature = "ck3")]
     pub fn loc_msg<E: ErrorLoc, S: Into<String>>(self, eloc: E, msg: S) -> ReportBuilderStage3 {
         let length = eloc.loc_length();
         ReportBuilderStage3 {


### PR DESCRIPTION
Closes #209

Existing file and folder matching behaviour is preserved.
Existing file filters which contain any of '?', '*', and '[' will require an update to escape these characters.
Most glob patterns will have to be quoted in the config, or the lexer will split them into different tokens.