### PR TITLE
fix(vic3): state_region definitions can accept multiple traits fields

### DIFF
--- a/src/validator.rs
+++ b/src/validator.rs
@@ -1191,7 +1191,7 @@ impl<'a> Validator<'a> {
     }
 
     /// Just like [`Validator::field_validated_list`], but expect any number of `name` fields in the block.
-    #[cfg(any(feature = "ck3", feature = "hoi4"))]
+    #[cfg(any(feature = "ck3", feature = "hoi4", feature = "vic3"))]
     pub fn multi_field_validated_list<F>(&mut self, name: &str, mut f: F) -> bool
     where
         F: FnMut(&Token, &Everything),
@@ -1206,7 +1206,7 @@ impl<'a> Validator<'a> {
     }
 
     /// Just like [`Validator::field_list_items`], but expect any number of `name` fields in the block.
-    #[cfg(any(feature = "ck3", feature = "hoi4"))]
+    #[cfg(any(feature = "ck3", feature = "hoi4", feature = "vic3"))]
     pub fn multi_field_list_items(&mut self, name: &str, item: Item) -> bool {
         let sev = self.max_severity;
         self.multi_field_validated_list(name, |token, data| {

--- a/src/vic3/data/state_regions.rs
+++ b/src/vic3/data/state_regions.rs
@@ -33,7 +33,7 @@ impl DbKind for StateRegion {
         vd.field_list_items("provinces", Item::Province);
         vd.field_list_items("prime_land", Item::Province);
         vd.field_list_items("impassable", Item::Province);
-        vd.field_list_items("traits", Item::StateTrait);
+        vd.multi_field_list_items("traits", Item::StateTrait);
 
         // TODO: verify that they're all there? except "port" for non-coastal state regions.
         for hub in &["city", "port", "mine", "farm", "wood"] {


### PR DESCRIPTION
Why would you define the field multiple times when you can combine them into a single list? Idk, but it works and vanilla uses it.