### PR TITLE
fix(vic3): Multiple treaty article modifier blocks are valid and work

### DIFF
--- a/src/vic3/data/treaty_articles.rs
+++ b/src/vic3/data/treaty_articles.rs
@@ -159,7 +159,7 @@ impl DbKind for TreatyArticle {
         }
 
         for modifier in &["source_modifier", "target_modifier", "mutual_modifier"] {
-            vd.field_validated_block(modifier, |block, data| {
+            vd.multi_field_validated_block(modifier, |block, data| {
                 let vd = Validator::new(block, data);
                 validate_modifs(block, data, ModifKinds::all(), vd);
             });


### PR DESCRIPTION
See vanilla military assistance article

I've tested all three source, target, and mutual modifiers just to be sure