### PR TITLE
Suppress unnecessarily repeated errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ The various path options are only needed if Tiger can't find the paths on its ow
 * `--show-vanilla` Show errors in the base game script code as well as the mod's
 * `--show-mods` Show errors in secondary loaded mods as well as the main mod
 * `--json` Output the reports in JSON format
+* `--consolidate` Log only the first occurrence of certain errors (such as missing items)
 * `--unused` Warn about items that are defined but unused (not yet accurate)
 * `--no-color` Omit color from the output
 * `--suppress` *PATH* Load a JSON file of reports to remove from the output (see section above)

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -13,6 +13,13 @@ use crate::token::Token;
 pub type TigerHashMap<K, V> = HashMap<K, V>;
 pub type TigerHashSet<T> = HashSet<T>;
 
+#[macro_export]
+macro_rules! set {
+    ( $x:expr ) => {
+        ahash::AHashSet::from($x).into()
+    };
+}
+
 /// Warns about a redefinition of a database item
 pub fn dup_error(key: &Token, other: &Token, id: &str) {
     warn(ErrorKey::DuplicateItem)

--- a/src/report/writer.rs
+++ b/src/report/writer.rs
@@ -21,6 +21,7 @@ pub fn log_report<O: Write + Send>(
     output: &mut O,
     report: &LogReportMetadata,
     pointers: &LogReportPointers,
+    additional: usize,
 ) {
     let indentation = pointer_indentation(pointers);
     // Log error lvl and message:
@@ -37,6 +38,10 @@ pub fn log_report<O: Write + Send>(
     // Log the info line, if one exists.
     if let Some(info) = &report.info {
         log_line_info(errors, output, indentation, info);
+    }
+    // Log the additional count, if it's more than zero
+    if additional > 0 {
+        log_count(errors, output, indentation, additional);
     }
     // Write a blank line to visually separate reports:
     _ = writeln!(output);
@@ -92,6 +97,17 @@ fn log_line_info<O: Write + Send>(errors: &Errors, output: &mut O, indentation: 
         errors.styles.style(Styled::Info).paint(info.to_string()),
     ];
     _ = writeln!(output, "{}", ANSIStrings(line_info));
+}
+
+/// Log the additional number of this error that were found in other locations
+fn log_count<O: Write + Send>(errors: &Errors, output: &mut O, indentation: usize, count: usize) {
+    let line_count: &[ANSIString<'static>] = &[
+        errors.styles.style(Styled::Default).paint(format!("{:width$}", "", width = indentation)),
+        errors.styles.style(Styled::Location).paint("-->"),
+        errors.styles.style(Styled::Default).paint(" "),
+        errors.styles.style(Styled::Location).paint(format!("and {count} other locations")),
+    ];
+    _ = writeln!(output, "{}", ANSIStrings(line_count));
 }
 
 /// Log the line containing the location's mod name and filename.

--- a/tiger-bin-shared/src/auto.rs
+++ b/tiger-bin-shared/src/auto.rs
@@ -165,13 +165,12 @@ fn validate_mod(
     // The colors can be enabled again in the config file.
     everything.load_output_settings(false);
     everything.load_config_filtering_rules();
-    emit_reports(&mut output, false);
+    emit_reports(&mut output, false, false);
 
     everything.load_all();
     everything.validate_all();
     everything.check_rivers();
-
-    emit_reports(&mut output, false);
+    emit_reports(&mut output, false, false);
 
     // Properly dropping `everything` takes a noticeable amount of time, and we're exiting anyway.
     forget(everything);


### PR DESCRIPTION
Some errors don't need to be reported more than once. For example, a missing item report is probably due either to single typo, or an actual missing item that's resolved by adding the item. In the later case, all instances of the error are resolved not at the error location, but by adding the item. Pointing out additional locations is unnecessary and noisy.

This adds the ability to suppress repeated errors, consolidating them into an "And {} other locations" line in the output.

I just had the thought that maybe it would have better to leave error collection unchanged, and only consolidate when building the output, but I've already done it this way, so here's a draft PR and you can tell me the approach is no good if you'd prefer something else.

```
warning(missing-item): custom localization random_free_state_of_place not defined in common/customizable_localization/
  --> [Vic3] localization/english/acw_text_l_english.yml
39 |  acw_events.7.t:0 "The Free State of [SCOPE.GetRootScope.GetCountry.GetCustom('random_free_state_of_place')]"
   |                                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^
  --> And 21 other locations
  ```