### PR TITLE
perf: Localization

### DIFF
--- a/src/everything.rs
+++ b/src/everything.rs
@@ -939,7 +939,9 @@ impl Everything {
     pub(crate) fn mark_used(&self, itype: Item, key: &str) {
         match itype {
             Item::File => self.fileset.mark_used(key),
-            Item::Localization => self.localization.mark_used(key),
+            Item::Localization => {
+                self.localization.mark_used_return_exists(key);
+            }
             _ => (),
         }
     }


### PR DESCRIPTION
**Avoid unnecessary localisation database access**
The expensive operation here is key hashing. This PR tries to reduce `HashMap::get()` calls to 1 per language for each entry point to the Localization module. It does this by introducing `mark_used_lang()` which can be used by code that is already iterating over the languages, and having `mark_used()` and `mark_used_lang()` double as existence checks, removing the need to call `exists()` or `exists_lang()` in many places.

~~**Replaces bitarray storage with `[bool; N]`**
The primary reader of these fields is `Localization::iter_lang_idx()` which can't make use of bitwise parallelism. Additionally, it returns an iterator, giving poor temporal locality to the array access and negating any cache benefits. Replacing the bit arrays with standard bool arrays reduces total Ir cost of vic3-tiger by over 4%.~~