### PR TITLE
perf: Reduce unneeded hashing when loading provinces

### DIFF
--- a/src/everything.rs
+++ b/src/everything.rs
@@ -1380,4 +1380,16 @@ mod benchmark {
                 everything.fileset.handle(&mut everything.provinces_vic3, &everything.parser);
             });
     }
+
+    #[divan::bench(args = internal_benches::vic3::bench_mods())]
+    fn load_localization(bencher: Bencher, (vanilla_dir, modpath): (&str, &PathBuf)) {
+        bencher
+            .with_inputs(|| {
+                Everything::new(None, Some(Path::new(vanilla_dir)), None, None, modpath, vec![])
+                    .unwrap()
+            })
+            .bench_local_refs(|everything| {
+                everything.fileset.handle(&mut everything.localization, &everything.parser);
+            });
+    }
 }


### PR DESCRIPTION
```
before                    fastest       │ slowest       │ median        │ mean          │ samples │ iters
 ╰─ load_provinces_ck3    85.56 ms      │ 91.24 ms      │ 86.72 ms      │ 87.08 ms      │ 100     │ 100
 ╰─ load_provinces_vic3   172.5 ms      │ 204.5 ms      │ 174.7 ms      │ 178.5 ms      │ 100     │ 100
after
 ╰─ load_provinces_ck3    61.14 ms      │ 93.04 ms      │ 72.71 ms      │ 75.13 ms      │ 100     │ 100
 ╰─ load_provinces_vic3   61.11 ms      │ 63.54 ms      │ 62.01 ms      │ 62.06 ms      │ 100     │ 100
```

It's a minor improvement for total runtime. Being able to write internal benchmarks is a bigger deal