### PR TITLE
Simd experiment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,11 @@ herrmod1
 herrmod2
 htest.sh
 htestmod.sh
+
+internal_benches/ck3.toml
+
+internal_benches/vic3.toml
+
+benches/ck3.toml
+
+benches/vic3.toml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2721,6 +2721,7 @@ dependencies = [
  "inventory",
  "lalrpop",
  "lalrpop-util",
+ "memchr",
  "murmur3",
  "phf 0.12.1",
  "png",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
  "strum",
  "tiger-bin-shared",
  "tiger-lib",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -363,6 +363,7 @@ dependencies = [
  "anstyle",
  "clap_lex",
  "strsim",
+ "terminal_size",
 ]
 
 [[package]]
@@ -388,6 +389,12 @@ name = "colorchoice"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+
+[[package]]
+name = "condtype"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf0a07a401f374238ab8e2f11a104d2851bf9ce711ec69804834de8af45c7af"
 
 [[package]]
 name = "console"
@@ -623,6 +630,31 @@ name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "divan"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a405457ec78b8fe08b0e32b4a3570ab5dff6dd16eb9e76a5ee0a9d9cbd898933"
+dependencies = [
+ "cfg-if",
+ "clap",
+ "condtype",
+ "divan-macros",
+ "libc",
+ "regex-lite",
+]
+
+[[package]]
+name = "divan-macros"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9556bc800956545d6420a640173e5ba7dfa82f38d3ea5a167eb555bc69ac3323"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -967,7 +999,7 @@ dependencies = [
  "serde_json",
  "tiger-bin-shared",
  "tiger-lib",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]
@@ -1244,6 +1276,16 @@ dependencies = [
  "portable-atomic",
  "unicode-width",
  "web-time",
+]
+
+[[package]]
+name = "internal_benches"
+version = "0.0.0"
+dependencies = [
+ "divan",
+ "serde",
+ "tiger-lib",
+ "toml 0.9.2",
 ]
 
 [[package]]
@@ -2071,6 +2113,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-lite"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a49587ad06b26609c52e423de037e7f57f20d53535d66e08c695f347df952a"
+
+[[package]]
 name = "regex-syntax"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2325,9 +2373,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.140"
+version = "1.0.141"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
+checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
 dependencies = [
  "itoa",
  "memchr",
@@ -2340,6 +2388,15 @@ name = "serde_spanned"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40734c41988f7306bb04f0ecf60ec0f3f1caa34290e4e8ea471dcd3346483b83"
 dependencies = [
  "serde",
 ]
@@ -2574,6 +2631,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45c6481c4829e4cc63825e62c49186a34538b7b2750b73b266581ffb612fb5ed"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2646,9 +2713,11 @@ dependencies = [
  "bitflags 2.9.1",
  "bitvec",
  "bumpalo",
+ "divan",
  "encoding_rs",
  "glob",
  "image",
+ "internal_benches",
  "inventory",
  "lalrpop",
  "lalrpop-util",
@@ -2795,9 +2864,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_edit",
+]
+
+[[package]]
+name = "toml"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed0aee96c12fa71097902e0bb061a5e1ebd766a6636bb605ba401c45c1650eac"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 1.0.0",
+ "toml_datetime 0.7.0",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
 ]
 
 [[package]]
@@ -2810,6 +2894,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bade1c3e902f58d73d3f294cd7f20391c1cb2fbcb643b73566bc773971df91e3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2817,9 +2910,18 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap",
  "serde",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
  "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97200572db069e74c512a14117b296ba0a80a30123fbbb5aa1f4a348f639ca30"
+dependencies = [
  "winnow",
 ]
 
@@ -2828,6 +2930,12 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
+name = "toml_writer"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fcc842091f2def52017664b53082ecbbeb5c7731092bad69d2c63050401dfd64"
 
 [[package]]
 name = "tower"
@@ -2996,7 +3104,7 @@ dependencies = [
  "serde_json",
  "tiger-bin-shared",
  "tiger-lib",
- "toml",
+ "toml 0.8.23",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2726,6 +2726,7 @@ dependencies = [
  "phf 0.12.1",
  "png",
  "rayon",
+ "regex",
  "serde",
  "serde_json",
  "strum",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "hoi4-tiger",
     "tiger-bin-shared",
     "utils",
+    "internal_benches",
     ".",
 ]
 
@@ -28,11 +29,14 @@ vic3 = ["jomini"]
 imperator = ["jomini"]
 jomini = ["image/png", "dep:png"]
 hoi4 = ["image/bmp", "dep:tinybmp"]
+internal_benches = ["dep:internal_benches", "dep:divan"]
 
 [build-dependencies]
 lalrpop = "0.22.0"
 
 [dependencies]
+internal_benches = { path = "internal_benches", optional = true }
+divan = { version = "0.1.21", optional = true }
 ansiterm = "0.12.2"
 anyhow = "1"
 as-any = "0.3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ ahash = { version = "0.8", features = [
 ], default-features = false }
 murmur3 = "0.5.2"
 glob = "0.3.2"
+memchr = "2.7.5"
 
 [profile.bench]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ ahash = { version = "0.8", features = [
 murmur3 = "0.5.2"
 glob = "0.3.2"
 memchr = "2.7.5"
+regex = "1.11.1"
 
 [profile.bench]
 debug = true

--- a/README.md
+++ b/README.md
@@ -166,6 +166,26 @@ The various path options are only needed if Tiger can't find the paths on its ow
 * `--help` Print help.
 * `--version` Print version
 
+## Benchmarks
+
+First, create config files in `benchmarks/`. Copy the `.example` files and adjust the paths for your system.
+
+Whole system benchmarks are run with:
+```
+cargo bench -p ck3-tiger
+```
+They support baselines with:
+```
+cargo bench -p ck3-tiger -- --save-baseline my_baseline
+cargo bench -p ck3-tiger -- --baseline my_baseline
+```
+
+Internal benchmarks are run with:
+```
+cargo bench -p internal_benches --features ck3
+```
+They do not support baselines
+
 ## Contributions
 
 I welcome contributions and collaborations! Some forms that contributions can take:

--- a/benches/ck3.toml.example
+++ b/benches/ck3.toml.example
@@ -1,0 +1,4 @@
+vanilla_dir = "/home/user/.steam/steam/steamapps/common/Crusader Kings III/"
+modfile_dir = "../mod-test-vanilla"
+modfile_paths = []
+sample_size = 10

--- a/benches/vic3.toml.example
+++ b/benches/vic3.toml.example
@@ -1,0 +1,4 @@
+vanilla_dir = "/home/user/.steam/steam/steamapps/common/Victoria 3/"
+#mod_dir = ".."
+mod_paths = ["../mod-test-vanilla"]
+sample_size = 10

--- a/ck3-tiger/benches/criterion.rs
+++ b/ck3-tiger/benches/criterion.rs
@@ -6,7 +6,7 @@ use std::{
 };
 use tiger_lib::{Everything, ModFile};
 
-static CONFIG_PATH: &str = "./benches/config.toml";
+static CONFIG_PATH: &str = "../benches/ck3.toml";
 
 // Sample Config File:
 // vanilla_dir = "..."

--- a/internal_benches/Cargo.toml
+++ b/internal_benches/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "internal_benches"
+edition = "2021"
+
+[features]
+ck3 = ["tiger-lib/ck3"]
+vic3 = ["tiger-lib/vic3"]
+
+[dependencies]
+divan = "0.1.21"
+serde = "1.0.219"
+toml = "0.9.2"
+
+[dev-dependencies]
+tiger-lib = { path = "..", version = "1.11.0", default-features = false, features = ["internal_benches"] }
+
+[[bench]]
+name = "internals"
+harness = false

--- a/internal_benches/benches/internals.rs
+++ b/internal_benches/benches/internals.rs
@@ -1,0 +1,9 @@
+use tiger_lib::Game;
+
+fn main() {
+    #[cfg(feature = "ck3")]
+    Game::set(Game::Ck3).unwrap();
+    #[cfg(feature = "vic3")]
+    Game::set(Game::Vic3).unwrap();
+    divan::main();
+}

--- a/internal_benches/src/ck3.rs
+++ b/internal_benches/src/ck3.rs
@@ -1,0 +1,36 @@
+use serde::Deserialize;
+use std::{fs, path::PathBuf, sync::LazyLock};
+
+static CONFIG_PATH: &str = "../benches/ck3.toml";
+
+// Sample Config File:
+// vanilla_dir = "..."
+// modfile_dir = "..."
+// modfile_paths = ["...", "..."]
+
+#[derive(Deserialize)]
+struct Config {
+    vanilla_dir: String,
+    modfile_dir: Option<String>,
+    modfile_paths: Vec<String>,
+}
+
+static CONFIG: LazyLock<Config> = LazyLock::new(|| {
+    let content = fs::read_to_string(CONFIG_PATH).unwrap();
+    toml::from_str(&content).unwrap()
+});
+static MODFILE_PATHS: LazyLock<Vec<PathBuf>> = LazyLock::new(|| {
+    let mut modfile_paths = CONFIG.modfile_paths.iter().map(PathBuf::from).collect::<Vec<_>>();
+    if let Some(modfile_dir) = &CONFIG.modfile_dir {
+        let iter =
+            fs::read_dir(modfile_dir).unwrap().filter_map(|entry| entry.ok()).filter_map(|entry| {
+                entry.file_name().to_string_lossy().ends_with(".mod").then(|| entry.path())
+            });
+        modfile_paths.extend(iter);
+    }
+    modfile_paths
+});
+
+pub fn bench_mods<'a>() -> impl Iterator<Item = (&'a str, &'a PathBuf)> {
+    MODFILE_PATHS.iter().map(move |modfile_path| (CONFIG.vanilla_dir.as_str(), modfile_path))
+}

--- a/internal_benches/src/lib.rs
+++ b/internal_benches/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod ck3;
+pub mod vic3;

--- a/internal_benches/src/vic3.rs
+++ b/internal_benches/src/vic3.rs
@@ -1,0 +1,36 @@
+use serde::Deserialize;
+use std::{fs, path::PathBuf, sync::LazyLock};
+
+static CONFIG_PATH: &str = "../benches/vic3.toml";
+
+// Sample Config File:
+// vanilla_dir = "..."
+// mod_dir = "..."
+// mod_paths = ["...", "..."]
+
+#[derive(Deserialize)]
+struct Config {
+    vanilla_dir: String,
+    mod_dir: Option<String>,
+    mod_paths: Vec<String>,
+}
+
+static CONFIG: LazyLock<Config> = LazyLock::new(|| {
+    let content = fs::read_to_string(CONFIG_PATH).unwrap();
+    toml::from_str(&content).unwrap()
+});
+static MOD_PATHS: LazyLock<Vec<PathBuf>> = LazyLock::new(|| {
+    let mut mod_paths = CONFIG.mod_paths.iter().map(PathBuf::from).collect::<Vec<_>>();
+    if let Some(mod_dir) = &CONFIG.mod_dir {
+        let iter =
+            fs::read_dir(mod_dir).unwrap().filter_map(|entry| entry.ok()).filter_map(|entry| {
+                entry.path().join(".metadata/metadata.json").is_file().then(|| entry.path())
+            });
+        mod_paths.extend(iter);
+    }
+    mod_paths
+});
+
+pub fn bench_mods<'a>() -> impl Iterator<Item = (&'a str, &'a PathBuf)> {
+    MOD_PATHS.iter().map(move |mod_path| (CONFIG.vanilla_dir.as_str(), mod_path))
+}

--- a/mod-test-vanilla/.metadata/metadata.json
+++ b/mod-test-vanilla/.metadata/metadata.json
@@ -2,5 +2,5 @@
 	"name": "Vanilla test mod",
 	"id": "mod-test-vanilla",
 	"version": "1.0",
-	"supported_game_version": "1.3.6",
+	"supported_game_version": "1.3.6"
 }

--- a/src/ck3/data/provinces.rs
+++ b/src/ck3/data/provinces.rs
@@ -10,7 +10,7 @@ use crate::db::{Db, DbKind};
 use crate::everything::Everything;
 use crate::fileset::{FileEntry, FileHandler};
 use crate::game::GameFlags;
-use crate::helpers::{TigerHashMap, TigerHashSet};
+use crate::helpers::{TigerHashMap, TigerHashSet, TigerIterHelpers};
 use crate::item::{Item, ItemLoader, LoadAsFile, Recursive};
 use crate::parse::csv::{parse_csv, read_csv};
 use crate::parse::ParserMemory;
@@ -320,7 +320,7 @@ impl FileHandler<FileContent> for Ck3Provinces {
             }
             FileContent::Provinces(img) => {
                 if let DynamicImage::ImageRgb8(img) = img {
-                    for pixel in img.pixels().copied() {
+                    for pixel in img.pixels().skip_repeated().copied() {
                         unsafe {
                             // SAFETY: `ColorBitArray::index` is guaranteed to return a valid index
                             self.colors

--- a/src/data/localization.rs
+++ b/src/data/localization.rs
@@ -799,17 +799,18 @@ impl FileHandler<(Language, Vec<LocaEntry>)> for Localization {
         }
 
         for loca in vec.drain(..) {
-            if !is_replace_path(entry.path()) {
-                if let Some(other) = hash.get(loca.key.as_str()) {
+            hash.entry(loca.key.to_string())
+                .and_modify(|other| {
                     // other.key and loca.key are in the other order than usual here,
                     // because in loca the older definition overrides the later one.
-                    if other.key.loc.kind == entry.kind() && other.orig != loca.orig {
+                    if !is_replace_path(entry.path())
+                        && other.key.loc.kind == entry.kind()
+                        && other.orig != loca.orig
+                    {
                         dup_error(&other.key, &loca.key, "localization");
-                        continue;
                     }
-                }
-            }
-            hash.insert(loca.key.to_string(), loca);
+                })
+                .or_insert(loca);
         }
     }
 }

--- a/src/everything.rs
+++ b/src/everything.rs
@@ -1343,3 +1343,35 @@ impl Drop for Everything {
         MACRO_MAP.clear();
     }
 }
+
+#[cfg(feature = "internal_benches")]
+mod benchmark {
+    use super::*;
+    use divan::Bencher;
+
+    #[cfg(feature = "ck3")]
+    #[divan::bench(args = internal_benches::ck3::bench_mods())]
+    fn load_provinces_ck3(bencher: Bencher, (vanilla_dir, modpath): (&str, &PathBuf)) {
+        bencher
+            .with_inputs(|| {
+                Everything::new(None, Some(Path::new(vanilla_dir)), None, None, modpath, vec![])
+                    .unwrap()
+            })
+            .bench_local_refs(|everything| {
+                everything.fileset.handle(&mut everything.provinces_ck3, &everything.parser);
+            });
+    }
+
+    #[cfg(feature = "vic3")]
+    #[divan::bench(args = internal_benches::vic3::bench_mods())]
+    fn load_provinces_vic3(bencher: Bencher, (vanilla_dir, modpath): (&str, &PathBuf)) {
+        bencher
+            .with_inputs(|| {
+                Everything::new(None, Some(Path::new(vanilla_dir)), None, None, modpath, vec![])
+                    .unwrap()
+            })
+            .bench_local_refs(|everything| {
+                everything.fileset.handle(&mut everything.provinces_vic3, &everything.parser);
+            });
+    }
+}

--- a/src/everything.rs
+++ b/src/everything.rs
@@ -1374,4 +1374,16 @@ mod benchmark {
                 everything.fileset.handle(&mut everything.provinces_vic3, &everything.parser);
             });
     }
+
+    #[divan::bench(args = internal_benches::vic3::bench_mods())]
+    fn load_localization(bencher: Bencher, (vanilla_dir, modpath): (&str, &PathBuf)) {
+        bencher
+            .with_inputs(|| {
+                Everything::new(None, Some(Path::new(vanilla_dir)), None, None, modpath, vec![])
+                    .unwrap()
+            })
+            .bench_local_refs(|everything| {
+                everything.fileset.handle(&mut everything.localization, &everything.parser);
+            });
+    }
 }

--- a/src/helpers.rs
+++ b/src/helpers.rs
@@ -235,3 +235,41 @@ pub fn camel_case_to_separated_words(s: &str) -> String {
     }
     temp_s
 }
+
+pub struct SkipRepeated<I, T>
+where
+    I: Iterator<Item = T>,
+    T: PartialEq + Copy,
+{
+    iter: I,
+    last: Option<T>,
+}
+
+impl<I, T> Iterator for SkipRepeated<I, T>
+where
+    I: Iterator<Item = T>,
+    T: PartialEq + Copy,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let next = self.iter.next();
+            if next != self.last || self.last.is_none() {
+                self.last = next;
+                return self.last;
+            }
+        }
+    }
+}
+
+pub trait TigerIterHelpers: Iterator {
+    fn skip_repeated<T>(self) -> SkipRepeated<Self, Self::Item>
+    where
+        Self: Sized + Iterator<Item = T>,
+        T: PartialEq + Copy,
+    {
+        SkipRepeated { iter: self, last: None }
+    }
+}
+impl<T> TigerIterHelpers for T where T: Iterator + ?Sized {}

--- a/src/imperator/data/provinces.rs
+++ b/src/imperator/data/provinces.rs
@@ -6,7 +6,7 @@ use image::{DynamicImage, Rgb};
 use crate::block::Block;
 use crate::everything::Everything;
 use crate::fileset::{FileEntry, FileHandler};
-use crate::helpers::{TigerHashMap, TigerHashSet};
+use crate::helpers::{TigerHashMap, TigerHashSet, TigerIterHelpers};
 use crate::item::Item;
 use crate::parse::csv::{parse_csv, read_csv};
 use crate::parse::ParserMemory;
@@ -262,7 +262,7 @@ impl FileHandler<FileContent> for ImperatorProvinces {
             }
             FileContent::Provinces(img) => {
                 if let DynamicImage::ImageRgb8(img) = img {
-                    for pixel in img.pixels() {
+                    for pixel in img.pixels().skip_repeated() {
                         self.colors.insert(*pixel);
                     }
                 }

--- a/src/vic3/data/provinces.rs
+++ b/src/vic3/data/provinces.rs
@@ -4,7 +4,7 @@ use image::{DynamicImage, Rgb};
 
 use crate::everything::Everything;
 use crate::fileset::{FileEntry, FileHandler};
-use crate::helpers::TigerHashSet;
+use crate::helpers::{TigerHashSet, TigerIterHelpers};
 use crate::item::Item;
 use crate::parse::ParserMemory;
 use crate::report::{err, report, ErrorKey, Severity};
@@ -86,7 +86,7 @@ impl FileHandler<DynamicImage> for Vic3Provinces {
     fn handle_file(&mut self, entry: &FileEntry, img: DynamicImage) {
         self.provinces_png = Some(entry.clone());
         if let DynamicImage::ImageRgb8(img) = img {
-            for pixel in img.pixels() {
+            for pixel in img.pixels().skip_repeated() {
                 self.colors.insert(*pixel);
             }
         }

--- a/vic3-tiger/benches/criterion.rs
+++ b/vic3-tiger/benches/criterion.rs
@@ -7,7 +7,7 @@ use std::{
 };
 use tiger_lib::{Everything, Game};
 
-static CONFIG_PATH: &str = "./benches/config.toml";
+static CONFIG_PATH: &str = "../benches/vic3.toml";
 
 // Sample Config File:
 // vanilla_dir = "..."


### PR DESCRIPTION
Very limited test of different character search routines

Inclusive Ir cost
```
find_dquote_chars : 899 317 865
find_dquote_bytes : 529 487 627
find_dquote_regex : 710 110 291
find_dquote_simd  : 175 174 691
```
The simd enabled function picked an avx2 implementation on my machine. Other architectures might have different results


measurements taken with
```
cargo install cargo-valgrind
VALGRINDFLAGS="--tool=callgrind --separate-callers=4 --collect-bus=yes --collect-jumps=yes --collect-systime=yes" cargo valgrind run --profile bench -p vic3-tiger -- ./mod-test-vanilla/ --show-vanilla
```