### PR TITLE
feat(vic3): Validate modifier flow with add_modifier

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -195,7 +195,7 @@ impl Db {
         }
     }
 
-    #[cfg(feature = "ck3")] // vic3 happens not to use
+    #[allow(dead_code)]
     pub fn validate_call(
         &self,
         item: Item,

--- a/src/everything.rs
+++ b/src/everything.rs
@@ -1082,7 +1082,7 @@ impl Everything {
         self.database.validate_use(itype, key, block, self);
     }
 
-    #[cfg(feature = "ck3")] // happens not to be used by vic3
+    #[allow(dead_code)]
     pub(crate) fn validate_call(
         &self,
         itype: Item,

--- a/src/report/builder.rs
+++ b/src/report/builder.rs
@@ -71,7 +71,7 @@ impl ReportBuilderStage1 {
 
     /// Sets the main report message.
     pub fn msg<S: Into<String>>(self, msg: S) -> ReportBuilderStage2 {
-        ReportBuilderStage2 { stage1: self, msg: msg.into(), info: None }
+        ReportBuilderStage2 { stage1: self, msg: msg.into(), info: None, wiki: None }
     }
 }
 
@@ -81,6 +81,7 @@ pub struct ReportBuilderStage2 {
     stage1: ReportBuilderStage1,
     msg: String,
     info: Option<String>,
+    wiki: Option<String>,
 }
 
 impl ReportBuilderStage2 {
@@ -97,12 +98,21 @@ impl ReportBuilderStage2 {
         self
     }
 
+    /// Optional step. Adds a wiki section to the report.
+    #[allow(dead_code)]
+    pub fn wiki<S: Into<String>>(mut self, wiki: S) -> Self {
+        let wiki = wiki.into();
+        self.wiki = if wiki.is_empty() { None } else { Some(wiki) };
+        self
+    }
+
     pub fn loc<E: ErrorLoc>(self, eloc: E) -> ReportBuilderFull {
         let length = eloc.loc_length();
         ReportBuilderFull {
             stage1: self.stage1,
             msg: self.msg,
             info: self.info,
+            wiki: self.wiki,
             pointers: vec![PointedMessage { loc: eloc.into_loc(), length, msg: None }],
         }
     }
@@ -113,12 +123,19 @@ impl ReportBuilderStage2 {
             stage1: self.stage1,
             msg: self.msg,
             info: self.info,
+            wiki: self.wiki,
             pointers: vec![PointedMessage { loc: eloc.into_loc(), length, msg: Some(msg.into()) }],
         }
     }
 
     pub fn pointers(self, pointers: LogReportPointers) -> ReportBuilderFull {
-        ReportBuilderFull { stage1: self.stage1, msg: self.msg, info: self.info, pointers }
+        ReportBuilderFull {
+            stage1: self.stage1,
+            msg: self.msg,
+            info: self.info,
+            wiki: self.wiki,
+            pointers,
+        }
     }
 
     pub fn abbreviated<E: ErrorLoc>(self, eloc: E) -> ReportBuilderAbbreviated {
@@ -126,6 +143,7 @@ impl ReportBuilderStage2 {
             stage1: self.stage1,
             msg: self.msg,
             info: self.info,
+            wiki: self.wiki,
             pointers: vec![PointedMessage { loc: eloc.into_loc(), length: 0, msg: None }],
         }
     }
@@ -137,6 +155,7 @@ pub struct ReportBuilderFull {
     stage1: ReportBuilderStage1,
     msg: String,
     info: Option<String>,
+    wiki: Option<String>,
     pointers: LogReportPointers,
 }
 
@@ -166,6 +185,7 @@ impl ReportBuilderFull {
                 confidence: self.stage1.2,
                 msg: self.msg,
                 info: self.info,
+                wiki: self.wiki,
                 style: LogReportStyle::Full,
             },
             self.pointers,
@@ -183,6 +203,7 @@ pub struct ReportBuilderAbbreviated {
     stage1: ReportBuilderStage1,
     msg: String,
     info: Option<String>,
+    wiki: Option<String>,
     pointers: LogReportPointers,
 }
 
@@ -196,6 +217,7 @@ impl ReportBuilderAbbreviated {
                 confidence: self.stage1.2,
                 msg: self.msg,
                 info: self.info,
+                wiki: self.wiki,
                 style: LogReportStyle::Abbreviated,
             },
             self.pointers,

--- a/src/report/report_struct.rs
+++ b/src/report/report_struct.rs
@@ -25,6 +25,8 @@ pub struct LogReportMetadata {
     pub msg: String,
     /// Optional info message to be printed at the end.
     pub info: Option<String>,
+    /// Optional wiki link to be printed at the end.
+    pub wiki: Option<String>,
     // /// Output style for this report
     pub style: LogReportStyle,
 }

--- a/src/report/writer.rs
+++ b/src/report/writer.rs
@@ -45,6 +45,11 @@ pub fn log_report<O: Write + Send>(
         log_line_info(errors, output, indentation, info);
     }
 
+    // Log the info line, if one exists.
+    if let Some(wiki) = &report.wiki {
+        log_line_wiki(errors, output, indentation, wiki);
+    }
+
     // Write a blank line to visually separate reports:
     _ = writeln!(output);
 }
@@ -97,6 +102,20 @@ fn log_line_info<O: Write + Send>(errors: &Errors, output: &mut O, indentation: 
         errors.styles.style(Styled::InfoTag).paint("Info:"),
         errors.styles.style(Styled::Default).paint(" "),
         errors.styles.style(Styled::Info).paint(info.to_string()),
+    ];
+    _ = writeln!(output, "{}", ANSIStrings(line_info));
+}
+
+/// Log the optional info line that is part of the overall report.
+fn log_line_wiki<O: Write + Send>(errors: &Errors, output: &mut O, indentation: usize, wiki: &str) {
+    let line_info: &[ANSIString<'static>] = &[
+        errors.styles.style(Styled::Default).paint(format!("{:width$}", "", width = indentation)),
+        errors.styles.style(Styled::Default).paint(" "),
+        errors.styles.style(Styled::Location).paint("="),
+        errors.styles.style(Styled::Default).paint(" "),
+        errors.styles.style(Styled::InfoTag).paint("Wiki:"),
+        errors.styles.style(Styled::Default).paint(" "),
+        errors.styles.style(Styled::Info).paint(wiki.to_string()),
     ];
     _ = writeln!(output, "{}", ANSIStrings(line_info));
 }

--- a/src/report/writer_json.rs
+++ b/src/report/writer_json.rs
@@ -36,6 +36,7 @@ pub fn log_report_json<O: Write + Send>(
         "key": report.key,
         "message": &report.msg,
         "info": &report.info,
+        "wiki": &report.wiki,
         "locations": pointers,
     });
 

--- a/src/vic3/data/modifiers.rs
+++ b/src/vic3/data/modifiers.rs
@@ -1,12 +1,14 @@
 use crate::block::Block;
+use crate::context::ScopeContext;
 use crate::db::{Db, DbKind};
 use crate::everything::Everything;
 use crate::game::GameFlags;
 use crate::item::{Item, ItemLoader};
-use crate::modif::validate_modifs;
+use crate::modif::{validate_modifs, ModifKinds as _};
 use crate::token::Token;
 use crate::validator::Validator;
 use crate::vic3::modif::ModifKinds;
+use crate::vic3::tables::modifs::modif_scope_kind;
 
 #[derive(Clone, Debug)]
 pub struct Modifier {}
@@ -34,5 +36,34 @@ impl DbKind for Modifier {
         vd.field_item("icon", Item::File);
 
         validate_modifs(block, data, ModifKinds::all(), vd);
+    }
+
+    fn validate_call(
+        &self,
+        _key: &Token,
+        block: &Block,
+        from: &Token,
+        _from_block: &Block,
+        data: &Everything,
+        sc: &mut ScopeContext,
+    ) {
+        let mut vd = Validator::new(block, data);
+
+        // Mark as known field
+        vd.field("icon");
+
+        // Ensure contained modifs are valid at this location
+        let (scopes, scope_reason) = sc.scopes_reason();
+        let scope_kinds = modif_scope_kind(scopes);
+        vd.unknown_fields(|key, _| {
+            if let Some(kind) = ModifKinds::lookup_modif(key, data, None) {
+                scope_kinds.require_from(
+                    kind,
+                    key,
+                    Some((from, scopes, scope_reason)),
+                    crate::Severity::Warning,
+                );
+            }
+        });
     }
 }

--- a/src/vic3/effect_validation.rs
+++ b/src/vic3/effect_validation.rs
@@ -62,13 +62,17 @@ pub fn validate_add_religion_sol_modifier(
 pub fn validate_add_enactment_modifier(
     _key: &Token,
     _block: &Block,
-    _data: &Everything,
+    data: &Everything,
     sc: &mut ScopeContext,
     mut vd: Validator,
     _tooltipped: Tooltipped,
 ) {
     vd.req_field("name");
-    vd.field_item("name", Item::Modifier);
+    vd.field_validated_value("name", |_key, mut vd| {
+        vd.item(Item::Modifier);
+        let value = vd.value();
+        data.validate_call(Item::Modifier, value, &Block::new(value.loc), sc);
+    });
     vd.field_script_value("multiplier", sc);
 }
 
@@ -82,12 +86,17 @@ pub fn validate_add_modifier(
     match bv {
         BV::Value(value) => {
             data.verify_exists(Item::Modifier, value);
+            data.validate_call(Item::Modifier, value, &Block::new(value.loc), sc);
         }
         BV::Block(block) => {
             let mut vd = Validator::new(block, data);
             vd.set_case_sensitive(false);
             vd.req_field("name");
-            vd.field_item("name", Item::Modifier);
+            vd.field_validated_value("name", |_key, mut vd| {
+                vd.item(Item::Modifier);
+                let value = vd.value();
+                data.validate_call(Item::Modifier, value, &Block::new(value.loc), sc);
+            });
             vd.field_script_value("multiplier", sc);
             validate_optional_duration(&mut vd, sc);
             vd.field_bool("is_decaying");

--- a/src/vic3/modif.rs
+++ b/src/vic3/modif.rs
@@ -59,7 +59,11 @@ impl ModifKinds {
             } else {
                 format!("valid modifiers are for {valid_kinds}")
             };
-            let mut report = report(ErrorKey::Modifiers, sev).msg(msg).info(info).loc(token);
+            let mut report = report(ErrorKey::Modifiers, sev)
+                .msg(msg)
+                .info(info)
+                .wiki("https://vic3.paradoxwikis.com/Modifier_types#Modifier_type_flow")
+                .loc(token);
             if let Some((token, _, reason)) = scope {
                 report = report
                     .loc_msg(token, "from this temporary modifier")

--- a/src/vic3/modif.rs
+++ b/src/vic3/modif.rs
@@ -3,10 +3,11 @@ use std::fmt::{Display, Formatter};
 use bitflags::bitflags;
 
 use crate::{
-    modif,
-    report::{err, ErrorKey},
+    context, modif,
+    report::{report, ErrorKey},
+    scopes::Scopes,
     vic3::tables::modifs::{lookup_modif, MODIF_FLOW_MAP},
-    Token,
+    Severity, Token,
 };
 
 bitflags! {
@@ -33,6 +34,42 @@ bitflags! {
     }
 }
 
+impl ModifKinds {
+    pub fn require_from(
+        self,
+        other: Self,
+        token: &Token,
+        scope: Option<(&Token, Scopes, &context::Reason)>,
+        sev: Severity,
+    ) {
+        let valid_kinds = self
+            .iter()
+            .map(|kind| *MODIF_FLOW_MAP.get(&kind).unwrap_or(&ModifKinds::empty()))
+            .reduce(ModifKinds::union)
+            .unwrap_or(self);
+        if !valid_kinds.intersects(other) {
+            let from = if let Some((_, scopes, _)) = scope {
+                format!("{scopes} scope")
+            } else {
+                self.to_string()
+            };
+            let msg = format!("`{token}` is a modifier for {other} and will not flow from {from}");
+            let info = if self.is_empty() {
+                format!("there are no valid modifiers for {from}")
+            } else {
+                format!("valid modifiers are for {valid_kinds}")
+            };
+            let mut report = report(ErrorKey::Modifiers, sev).msg(msg).info(info).loc(token);
+            if let Some((token, _, reason)) = scope {
+                report = report
+                    .loc_msg(token, "from this temporary modifier")
+                    .loc_msg(reason.token(), format!("scope was {}", reason.msg()));
+            }
+            report.push();
+        }
+    }
+}
+
 impl modif::ModifKinds for ModifKinds {
     fn lookup_modif(
         name: &crate::Token,
@@ -43,16 +80,7 @@ impl modif::ModifKinds for ModifKinds {
     }
 
     fn require(self, other: Self, token: &Token) {
-        let valid_kinds = self
-            .iter()
-            .map(|kind| *MODIF_FLOW_MAP.get(&kind).unwrap_or(&ModifKinds::empty()))
-            .reduce(ModifKinds::union)
-            .unwrap_or(self);
-        if !valid_kinds.intersects(other) {
-            let msg = format!("`{token}` is a modifier for {other} and will not flow from {self}");
-            let info = format!("valid modifiers are for {valid_kinds}");
-            err(ErrorKey::Modifiers).msg(msg).info(info).loc(token).push();
-        }
+        self.require_from(other, token, None, Severity::Error);
     }
 }
 

--- a/src/vic3/tables/modifs.rs
+++ b/src/vic3/tables/modifs.rs
@@ -27,6 +27,7 @@ pub fn lookup_modif(name: &Token, data: &Everything, warn: Option<Severity>) -> 
         report(ErrorKey::MissingItem, sev)
             .msg("modifier type definition does not exist")
             .info(info)
+            .wiki("https://vic3.paradoxwikis.com/Modifier_types#Defining_modifier_types")
             .loc(name)
             .push();
     }
@@ -45,6 +46,7 @@ fn lookup_modif_prefix(name: &Token) -> ModifKinds {
     untidy(ErrorKey::Modifiers)
         .msg("script only modifier does not use a valid prefix")
         .info("consider using a prefix to ensure the modifier flows to the intended scope")
+        .wiki("https://vic3.paradoxwikis.com/Modifier_types#Modifier_type_flow")
         .loc(name)
         .push();
     ModifKinds::all()


### PR DESCRIPTION
```
warning(modifiers): `interest_group_ig_industrialists_pol_str_mult` is a modifier for interest group and will not flow from state scope
   --> [Vic3] common/static_modifiers/content_4_modifiers.txt
403 |     interest_group_ig_industrialists_pol_str_mult = 0.05
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   --> [Vic3] events/russo_chinese_events.txt
379 |              add_modifier = modifier_vladivostok_civilian
    |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ <-- from this temporary modifier
332 |         random_state = {
    |         ^^^^^^^^^^^^ <-- scope was deduced from `random_state` here
    = Info: valid modifiers are for building, state, goods
    = Wiki: https://vic3.paradoxwikis.com/Modifier_types#Modifier_type_flow

untidy(modifiers): script only modifier does not use a valid prefix
    --> [Vic3] common/modifier_type_definitions/00_modifier_types.txt
2800 | dummy_modifier_type={
     | ^^^^^^^^^^^^^^^^^^^
     = Info: consider using a prefix to ensure the modifier flows to the intended scope
     = Wiki: https://vic3.paradoxwikis.com/Modifier_types#Modifier_type_flow
```